### PR TITLE
Add Support for JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ To compile the Headless submodule, you will need to run: `dotnet publish -f net8
 
 ### 0.0.3
 
-Update Headless back-end to latest version.
+- Update Headless back-end to latest version.
+- Add new VSCode command to evaluate JavaScript
+- Add new "auto" command which will evaluate based on the editor's currently selected language
 
 ### 0.0.2
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ Currently there are no settings, configuration options will be added in soon.
 
 If you want to build the extension VSIX locally and install it into VSCode, you will need to package it using the `vsce` tool. First install it via npm with: `npm install -g @vscode/vsce`. Then you can build and pack the VSIX file using: `vsce pack --out ./release/prototyper.x.x.x.vsix --yarn --pre-release`. Once done, you can install the extension into VSCode by opening up the extensions tab, clicking the context menu button, and selecting the option to install VSIX.
 
-Also note that the `dist` folder must contain a subfolder called `HeadlessNetCore` which houses the Headless compiled assemblies. At this point in time, building the submodule and copying it to this folder must be done manually before running the `vsce pack` command.
+Also note that the `dist` folder must contain a subfolder called `bin` which houses the Headless compiled assemblies. At this point in time, building the submodule and copying it to this folder must be done manually before running the `vsce pack` command.
 
-To compile the Headless submodule, you will need to run: `dotnet publish -f net8.0 -c Release` from the `./modules/Headless/HeadlessNetCore.` folder.
+To compile the Headless submodule, you will need to run: `dotnet publish -f net8.0 -c Release` from the `./modules/Headless/Headless.` folder.
 
 ## Release Notes
+
+### 0.0.3
+
+Update Headless back-end to latest version.
 
 ### 0.0.2
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,16 @@
   "contributes": {
     "commands": [
       {
+        "command": "extension.prototyper.evaluate",
+        "title": "Prototyper: Evaluate"
+      },
+      {
         "command": "extension.prototyper.evaluatecsharp",
-        "title": "Prototyper: Evaluate C# Script"
+        "title": "Prototyper: Evaluate C#"
+      },
+      {
+        "command": "extension.prototyper.evaluatejs",
+        "title": "Prototyper: Evaluate JavaScript"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "prototyper",
   "displayName": "Prototyper",
   "description": "Compile, test & debug* code snippets seamlessly inside VSCode!\r\n\r\n*Coming Soon!",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "publisher": "pwalkerdev",
   "icon": "./dist/logo/pt-logo.png",
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ function RunCSharpHeadless(editor: vscode.TextEditor, terminal: vscode.Terminal 
 	const executionDelay = terminal ? 0 : instance.terminalInitialisationDelay, // HACK: This is pretty crappy but if we create a new terminal then we have to wait until it is ready. I couldn't find a 'proper' way to do this
 		  token = uuid.new();
 	
-	(terminal ??= vscode.window.createTerminal(prototerminal.options)).sendText(`cmd.exe /c "${headless.netCoreModule.fsPath}" -l CSharp -i stream -t "${token}"`);
+	(terminal ??= vscode.window.createTerminal(prototerminal.options)).sendText(`cmd.exe /c "${headless.Location}" -l CSharp -i stream -t "${token}"`);
 
 	setTimeout(() => {
 		terminal!.sendText(''); // the empty line here serves no purpose - i just think it looks prettier

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ function RunCSharpHeadless(editor: vscode.TextEditor, terminal: vscode.Terminal 
 	const executionDelay = terminal ? 0 : instance.terminalInitialisationDelay, // HACK: This is pretty crappy but if we create a new terminal then we have to wait until it is ready. I couldn't find a 'proper' way to do this
 		  token = uuid.new();
 	
-	(terminal ??= vscode.window.createTerminal(prototerminal.options)).sendText(`dotnet "${headless.netCoreModule.fsPath}" stream "${token}"`);
+	(terminal ??= vscode.window.createTerminal(prototerminal.options)).sendText(`cmd.exe /c "${headless.netCoreModule.fsPath}" -l CSharp -i stream -t "${token}"`);
 
 	setTimeout(() => {
 		terminal!.sendText(''); // the empty line here serves no purpose - i just think it looks prettier

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,20 +2,22 @@ import * as vscode from 'vscode';
 import { headless, instance, uuid, prototerminal } from './global';
 
 export function activate(context: vscode.ExtensionContext) {
-    context.subscriptions.push(vscode.commands.registerCommand('extension.prototyper.evaluatecsharp', () => EvaluateEntryPoint(RunCSharpHeadless)));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.prototyper.evaluate', () => Evaluate()));
+	context.subscriptions.push(vscode.commands.registerCommand('extension.prototyper.evaluatecsharp', () => Evaluate("CSharp")));
+	context.subscriptions.push(vscode.commands.registerCommand('extension.prototyper.evaluatejs', () => Evaluate("JavaScript")));
 }
 
-function EvaluateEntryPoint(callback: (editor: vscode.TextEditor, terminal: vscode.Terminal | undefined) => void): void {
+function Evaluate(languageOverride: string | undefined = undefined): void {
 	if (vscode.window.activeTextEditor) {
-		callback(vscode.window.activeTextEditor, vscode.window.terminals.find(t => t.name === prototerminal.name));
+		RunHeadless(languageOverride, vscode.window.activeTextEditor, vscode.window.terminals.find(t => t.name === prototerminal.name));
 	}
 }
 
-function RunCSharpHeadless(editor: vscode.TextEditor, terminal: vscode.Terminal | undefined): void {
+function RunHeadless(languageOverride: string | undefined, editor: vscode.TextEditor, terminal: vscode.Terminal | undefined): void {
 	const executionDelay = terminal ? 0 : instance.terminalInitialisationDelay, // HACK: This is pretty crappy but if we create a new terminal then we have to wait until it is ready. I couldn't find a 'proper' way to do this
 		  token = uuid.new();
 	
-	(terminal ??= vscode.window.createTerminal(prototerminal.options)).sendText(`cmd.exe /c "${headless.Location}" -l CSharp -i stream -t "${token}"`);
+	(terminal ??= vscode.window.createTerminal(prototerminal.options)).sendText(`cmd.exe /c "${headless.Location}" -l ${languageOverride ?? editor.document.languageId} -i stream -t "${token}"`);
 
 	setTimeout(() => {
 		terminal!.sendText(''); // the empty line here serves no purpose - i just think it looks prettier

--- a/src/global.ts
+++ b/src/global.ts
@@ -8,9 +8,9 @@ export class instance {
 }
 
 export class headless {
-    private static readonly _searchPath: string[] = instance.isDebug ? ['.modules', 'Headless', 'HeadlessNetCore', 'bin', 'Debug', 'net8.0'] : ['dist', 'HeadlessNetCore'];
+    private static readonly _searchPath: string[] = instance.isDebug ? ['.modules', 'Headless', 'Headless', 'bin', 'Debug', 'net8.0'] : ['dist', 'bin'];
 
-    static readonly netCoreModule: vscode.Uri = vscode.Uri.file(path.join(instance.installationFolder, ...this._searchPath, 'HeadlessNetCore.dll'));
+    static readonly netCoreModule: vscode.Uri = vscode.Uri.file(path.join(instance.installationFolder, ...this._searchPath, 'Headless.exe'));
 }
 
 export class uuid {

--- a/src/global.ts
+++ b/src/global.ts
@@ -10,7 +10,7 @@ export class instance {
 export class headless {
     private static readonly _searchPath: string[] = instance.isDebug ? ['.modules', 'Headless', 'Headless', 'bin', 'Debug', 'net8.0'] : ['dist', 'bin'];
 
-    static readonly netCoreModule: vscode.Uri = vscode.Uri.file(path.join(instance.installationFolder, ...this._searchPath, 'Headless.exe'));
+    static readonly Location: string = vscode.Uri.file(path.join(instance.installationFolder, ...this._searchPath, 'Headless.exe')).fsPath;
 }
 
 export class uuid {


### PR DESCRIPTION
Following a new version of Headless, JavaScript can now be targeted. This update adds new commands for JS to VSCode to evaluate JavaScript, as well as a general `Evaluate Script` command which will choose a target based on the selection in the editor.